### PR TITLE
Arguments as list

### DIFF
--- a/src/main/java/com/github/greengerong/Command.java
+++ b/src/main/java/com/github/greengerong/Command.java
@@ -12,6 +12,8 @@ package com.github.greengerong;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Command {
     private String protractor;

--- a/src/main/java/com/github/greengerong/Command.java
+++ b/src/main/java/com/github/greengerong/Command.java
@@ -44,15 +44,20 @@ public class Command {
         return arguments;
     }
 
-    @Override
-    public String toString() {
-        return getCommand();
+    public List<String> getCommand() {
+          List<String> cmds = new ArrayList<String>();
+          String debugCmd = debug ? (debugBrk ? "--debug-brk" : "debug") : "";
+
+          if (!StringUtils.isBlank(debugCmd)) {
+                  cmds.add(debugCmd);
+          }
+
+          cmds.add(configFile.getAbsolutePath());
+
+          if (!StringUtils.isBlank(arguments)) {
+                  cmds.add(arguments);
+          }
+          return cmds;
     }
 
-    private String getCommand() {
-        return String.format("%s %s %s",
-                debug ? (debugBrk ? "--debug-brk" : "debug") : "",
-                configFile.getAbsolutePath(),
-                StringUtils.isBlank(arguments) ? "" : arguments).trim();
-    }
 }

--- a/src/main/java/com/github/greengerong/ProtractorService.java
+++ b/src/main/java/com/github/greengerong/ProtractorService.java
@@ -9,11 +9,12 @@
 
 package com.github.greengerong;
 
-import org.apache.maven.plugin.logging.Log;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+import org.apache.maven.plugin.logging.Log;
 
 public class ProtractorService {
     private boolean ignoreFailed;
@@ -92,7 +93,6 @@ public class ProtractorService {
 		} else {
 			cmds.add(command.getProtractor());
 			cmds.addAll(command.getCommand());
-			log.info("#### cmds " + cmds);
 			builder = new ProcessBuilder(cmds);
 		}
 		builder.redirectErrorStream(true);

--- a/src/main/java/com/github/greengerong/ProtractorService.java
+++ b/src/main/java/com/github/greengerong/ProtractorService.java
@@ -80,15 +80,23 @@ public class ProtractorService {
     }
 
 
-    private ProcessBuilder createProcessBuilder(Command command) {
-        ProcessBuilder builder;
-        if (OSUtils.isWindows()) {
-            builder = new ProcessBuilder("cmd.exe", "/C", command.getProtractor(), command.toString());
-        } else {
-            builder = new ProcessBuilder(command.getProtractor(), command.toString());
-        }
-        builder.redirectErrorStream(true);
-        return builder;
-    }
+	public ProcessBuilder createProcessBuilder(Command command) {
+		ProcessBuilder builder;
+		List<String> cmds = new ArrayList<String>();
+		if (OSUtils.isWindows()) {
+			cmds.add("cmd.exe");
+			cmds.add("/C");
+			cmds.add(command.getProtractor());
+			cmds.addAll(command.getCommand());
+			builder = new ProcessBuilder(cmds);
+		} else {
+			cmds.add(command.getProtractor());
+			cmds.addAll(command.getCommand());
+			log.info("#### cmds " + cmds);
+			builder = new ProcessBuilder(cmds);
+		}
+		builder.redirectErrorStream(true);
+		return builder;
+	}
 
 }

--- a/src/main/java/com/github/greengerong/ProtractorService.java
+++ b/src/main/java/com/github/greengerong/ProtractorService.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.maven.plugin.logging.Log;
 


### PR DESCRIPTION
In regards to my question on the argument parameter [1].

I would like to use the argument parameter as a way to pass maven properties into protractor at execution time and this did not work as I hoped.

Looking at the docs [2] and changing the argument to ProcessBuilder from a String to a List of Strings makes it work however.

Please review and consider a similar change. Thanks!
1. [https://github.com/greengerong/maven-ng-protractor/issues/3](url)
2. [https://docs.oracle.com/javase/8/docs/api/java/lang/ProcessBuilder.html](url)
